### PR TITLE
adds mailer settings for transactional emails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'noreply.wordsandmoves@gmail.com'
+  default from: "Words & Moves <postmaster@wordsandmoves.com>"
   layout 'mailer'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   def full_name
     "#{first_name} #{last_name}"
-  end 
+  end
 
   def self.from_omniauth(auth)
 	  where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,19 +26,10 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = false
   config.action_mailer.raise_delivery_errors = false
   # SMTP settings for gmail
-  config.action_mailer.smtp_settings = {
-   :address              => "smtp.gmail.com",
-   :port                 => 587,
-   :domain               => "gmail.com",
-   :user_name            => 'username',
-   :password             => 'password',
-   :authentication       =>  "plain",
-   :enable_starttls_auto => true
-  }
+
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,6 +55,7 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "words_and_music_#{Rails.env}"
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'Words & Moves <postmaster@wordsandmoves.com>'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/email_settings.rb
+++ b/config/initializers/email_settings.rb
@@ -1,0 +1,10 @@
+# config/initializers/email_settings.rb
+
+ActionMailer::Base.smtp_settings = {
+  user_name: 'SMTP_Injection',
+  password: "super_secret_key",
+  address: 'smtp.sparkpostmail.com',
+  port: 587,
+  enable_starttls_auto: true,
+  format: :html,
+}


### PR DESCRIPTION
Okay so I the mailer is now working for transactional emails through SparkPost. Here's what I have working so far.

- When a visitor subscriber he receives an email automatically thanking them for subscribing
<img width="590" alt="screen shot 2016-07-28 at 12 11 27 pm" src="https://cloud.githubusercontent.com/assets/15992549/17220974/b443ccf8-54bf-11e6-963a-365da35e17fc.png">

- The emails are sent through postmaster@wordsandmoves.com with Words & Moves as the name
<img width="600" alt="screen shot 2016-07-28 at 12 11 39 pm" src="https://cloud.githubusercontent.com/assets/15992549/17220990/c5bee846-54bf-11e6-8f9a-d87d793af8fd.png">

- Devise password reset is also set up with the mailer
<img width="594" alt="screen shot 2016-07-28 at 12 26 50 pm" src="https://cloud.githubusercontent.com/assets/15992549/17221003/cf990c84-54bf-11e6-942e-87ee1f096831.png">

This is pretty awesome and it took a while since it was my first time working with the mailer but it's been a good learning experience. So I have one part of issue #20 done, now we just need styling and specs. 😌