### PR TITLE
adds proper navigation urls and paths to region views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'devise'
 gem 'omniauth-facebook'
 gem 'react_on_rails'
 gem 'coveralls', require: false
+gem 'friendly_id'
 
 group :development do
   gem 'capistrano'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     ffi (1.9.14)
     foreman (0.82.0)
       thor (~> 0.19.1)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashie (3.4.4)
@@ -319,6 +321,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   factory_girl_rails
+  friendly_id
   jbuilder (~> 2.5)
   listen (~> 3.0.5)
   omniauth-facebook

--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -2,23 +2,43 @@ class RegionsController < ApplicationController
 
   def explore
     #currently have this so the navbar can work but the nav won't have a region name for the explore
-    @region = Region.find(2)
     @regions = Region.all
   end
 
+  def new
+    @region = Region.new
+  end
+
+  def create
+    @region = Region.new(region_params)
+    if @region.save
+      flash[:success] = "The new region was created!"
+      redirect_to :back
+    else
+      flash[:danger] = "Fix the errors"
+      redirect_to :back
+    end
+  end
+
   def feed
-    @region = Region.find(1)
-    @subregions = @region.subregions.all
+    @region = Region.friendly.find(params[:slug])
+    @events = @region.events
+    @posts = @region.posts
   end
 
   def event
-    #this will eventually get passed in params for the navbar
-    @region = Region.find(1)
+    @region = Region.friendly.find(params[:slug])
+    @event = @region.events.find(params[:id])
   end
 
   def post
-    #this will eventually get passed in params for the navbar
-    @region = Region.find(2)
+    @region = Region.friendly.find(params[:slug])
+    @post = @region.posts.find(params[:id])
   end
 
+  private
+
+  def region_params
+    params.require(:region).permit(:name)
+  end
 end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: cities
+#
+#  id           :integer          not null, primary key
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  subregion_id :integer
+#
+
 class City < ApplicationRecord
   has_many :events
   belongs_to :subregion

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,8 +2,11 @@
 #
 # Table name: comments
 #
-#  id   :integer          not null, primary key
-#  body :string
+#  id       :integer          not null, primary key
+#  body     :string
+#  user_id  :integer
+#  event_id :integer
+#  post_id  :integer
 #
 
 class Comment < ActiveRecord::Base

--- a/app/models/dislike.rb
+++ b/app/models/dislike.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: dislikes
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  item_type  :string
+#  item_id    :integer
+#
+
 class Dislike < ApplicationRecord
   belongs_to :user
   belongs_to :item, polymorphic: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,11 +2,15 @@
 #
 # Table name: events
 #
-#  id         :integer          not null, primary key
-#  title      :string
-#  body       :text
-#  location   :string
-#  event_date :datetime
+#  id          :integer          not null, primary key
+#  title       :string
+#  body        :text
+#  location    :string
+#  event_date  :datetime
+#  category_id :integer
+#  city_id     :integer
+#  user_id     :integer
+#  region_id   :integer
 #
 
 class Event < ActiveRecord::Base

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: likes
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  item_type  :string
+#  item_id    :integer
+#
+
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :item, polymorphic: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,9 +2,12 @@
 #
 # Table name: posts
 #
-#  id    :integer          not null, primary key
-#  title :string
-#  body  :text
+#  id          :integer          not null, primary key
+#  title       :string
+#  body        :text
+#  category_id :integer
+#  region_id   :integer
+#  user_id     :integer
 #
 
 class Post < ActiveRecord::Base

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -4,10 +4,15 @@
 #
 #  id   :integer          not null, primary key
 #  name :string
+#  slug :string
 #
 
 class Region < ActiveRecord::Base
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+
   has_many :posts
+  has_many :events
   has_many :subregions
 
   has_many :user_region_relations

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: rsvps
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  event_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class Rsvp < ApplicationRecord
   belongs_to :user
   belongs_to :event

--- a/app/models/subregion.rb
+++ b/app/models/subregion.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: subregions
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  region_id  :integer
+#
+
 class Subregion < ApplicationRecord
   has_many :cities
   has_many :events, through: :cities

--- a/app/models/subscriber.rb
+++ b/app/models/subscriber.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: subscribers
+#
+#  id         :integer          not null, primary key
+#  email      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class Subscriber < ApplicationRecord
   validates_presence_of :email
   validates_uniqueness_of :email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0), not null
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :inet
+#  last_sign_in_ip        :inet
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  admin                  :boolean
+#  username               :string
+#  first_name             :string
+#  last_name              :string
+#  provider               :string
+#  uid                    :string
+#
+
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/user_city_relation.rb
+++ b/app/models/user_city_relation.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: user_city_relations
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  city_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class UserCityRelation < ApplicationRecord
   belongs_to :user
   belongs_to :city

--- a/app/models/user_region_relation.rb
+++ b/app/models/user_region_relation.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: user_region_relations
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  region_id  :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class UserRegionRelation < ApplicationRecord
   belongs_to :user
   belongs_to :region

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-xs-6">
-            <% if params[:controller] == 'regions' %>
+            <% if params[:controller] == 'regions' && params[:action] != 'explore' %>
               <h2><%= @region.name %></h2>
             <% end %>
           </div>

--- a/app/views/regions/event.html.erb
+++ b/app/views/regions/event.html.erb
@@ -1,0 +1,6 @@
+<h1> Individual Event Page </h1>
+<h2><%= @event.title %></h2>
+<h3><%= @event.location %></h3>
+<h4><%= @event.event_date %></h4>
+
+<p><%= @event.body %></p>

--- a/app/views/regions/explore.html.erb
+++ b/app/views/regions/explore.html.erb
@@ -1,6 +1,5 @@
 <h1> This is where a list of cities will be </h1>
 
-<% @regions.each do |x| %>
-<h1><%= x.name %></h1>
-<h2>will implement link_to so clicking on the name sends to their feed page </h2>
+<% @regions.each do |region| %>
+<h1><%= link_to region.name, region_feed_path(region.slug) %>
 <% end %>

--- a/app/views/regions/feed.html.erb
+++ b/app/views/regions/feed.html.erb
@@ -1,0 +1,21 @@
+<h1> Events & Postings </h1>
+<div class="container-fluid">
+  <row>
+    <div class="col-lg-12 text-left">
+      <% @events.each do |event| %>
+      <h2><%= link_to event.title, region_event_path(slug: @region.slug, id: event.id) %></h2>
+      <h3><%= event.location %></h3>
+      <h4><%= event.event_date %></h4>
+      <p><%= event.body %></p>
+      <% end %>
+    </div>
+  </row>
+<row>
+  <div class="col-lg-12 text-left">
+    <% @posts.each do |post| %>
+    <h2><%= link_to post.title, region_post_path(slug: @region.slug, id: post.id) %></h2>
+    <p><%= post.body %></p>
+    <% end %>
+  </div>
+</row>
+</div>

--- a/app/views/regions/new.html.erb
+++ b/app/views/regions/new.html.erb
@@ -1,0 +1,12 @@
+<div class="container">
+  <%= form_for(@region) do |f| %>
+    <div class="field">
+      <%= f.label :name %><br />
+      <%= f.text_field :name, class: "form-control" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Create", class: "btn btn-primary button-100" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/regions/post.html.erb
+++ b/app/views/regions/post.html.erb
@@ -1,0 +1,3 @@
+<h1> Individual Post Page </h1>
+<h2><%= @post.title %></h2>
+<p><%= @post.body %></p>

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,14 +3,16 @@ Rails.application.routes.draw do
 
   get 'hello_world', to: 'hello_world#index'
   get 'feed', to: 'users#feed'
+  get 'region/new', to: 'regions#new'
   get 'explore', to: 'regions#explore'
-  get 'region/feed', to: 'regions#feed'
-  get 'region/feed/event', to: 'regions#event'
-  get 'region/feed/post', to: 'regions#post'
+  get '/:slug/feed', to: 'regions#feed', as: 'region_feed'
+  get '/:slug/event/:id', to: 'regions#event', as: 'region_event'
+  get '/:slug/post/:id', to: 'regions#post', as: 'region_post'
 
   resources :subscribers, only: [:create]
   resources :likes, only: [:create]
   resources :dislikes, only: [:create]
+  resources :regions, path: '', only: [:create, :update, :destroy]
 
   devise_for :users, :controllers => { :omniauth_callbacks => "users/facebook_callbacks" }
 

--- a/db/migrate/20160801165734_create_friendly_id_slugs.rb
+++ b/db/migrate/20160801165734_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/migrate/20160801165834_add_friendly_id_to_region.rb
+++ b/db/migrate/20160801165834_add_friendly_id_to_region.rb
@@ -1,0 +1,6 @@
+class AddFriendlyIdToRegion < ActiveRecord::Migration[5.0]
+  def change
+    add_column :regions, :slug, :string
+    add_index :regions, :slug, unique: true
+  end
+end

--- a/db/migrate/20160801170938_add_region_id_to_events.rb
+++ b/db/migrate/20160801170938_add_region_id_to_events.rb
@@ -1,0 +1,5 @@
+class AddRegionIdToEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :events, :region, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160730191359) do
+ActiveRecord::Schema.define(version: 20160801170938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,9 +55,23 @@ ActiveRecord::Schema.define(version: 20160730191359) do
     t.integer  "category_id"
     t.integer  "city_id"
     t.integer  "user_id"
+    t.integer  "region_id"
     t.index ["category_id"], name: "index_events_on_category_id", using: :btree
     t.index ["city_id"], name: "index_events_on_city_id", using: :btree
+    t.index ["region_id"], name: "index_events_on_region_id", using: :btree
     t.index ["user_id"], name: "index_events_on_user_id", using: :btree
+  end
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string   "slug",                      null: false
+    t.integer  "sluggable_id",              null: false
+    t.string   "sluggable_type", limit: 50
+    t.string   "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, using: :btree
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", using: :btree
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
   end
 
   create_table "likes", force: :cascade do |t|
@@ -83,6 +97,8 @@ ActiveRecord::Schema.define(version: 20160730191359) do
 
   create_table "regions", force: :cascade do |t|
     t.string "name"
+    t.string "slug"
+    t.index ["slug"], name: "index_regions_on_slug", unique: true, using: :btree
   end
 
   create_table "rsvps", force: :cascade do |t|
@@ -156,6 +172,7 @@ ActiveRecord::Schema.define(version: 20160730191359) do
   add_foreign_key "dislikes", "users"
   add_foreign_key "events", "categories"
   add_foreign_key "events", "cities"
+  add_foreign_key "events", "regions"
   add_foreign_key "events", "users"
   add_foreign_key "likes", "users"
   add_foreign_key "posts", "categories"

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,3 +1,11 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id   :integer          not null, primary key
+#  name :string
+#
+
 FactoryGirl.define do
   factory :category do
     sequence(:name) { |x| "Category #{x}"}

--- a/spec/factories/cities.rb
+++ b/spec/factories/cities.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: cities
+#
+#  id           :integer          not null, primary key
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  subregion_id :integer
+#
+
 FactoryGirl.define do
   factory :city do
     name "Oakland"

--- a/spec/factories/dislikes.rb
+++ b/spec/factories/dislikes.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: dislikes
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  item_type  :string
+#  item_id    :integer
+#
+
 FactoryGirl.define do
   factory :dislike do
     user

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :integer          not null, primary key
+#  title       :string
+#  body        :text
+#  location    :string
+#  event_date  :datetime
+#  category_id :integer
+#  city_id     :integer
+#  user_id     :integer
+#  region_id   :integer
+#
+
 FactoryGirl.define do
   factory :event do
     title "Test Event"

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: likes
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  item_type  :string
+#  item_id    :integer
+#
+
 FactoryGirl.define do
   factory :like do
     user

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id          :integer          not null, primary key
+#  title       :string
+#  body        :text
+#  category_id :integer
+#  region_id   :integer
+#  user_id     :integer
+#
+
 FactoryGirl.define do
   factory :post do
     title "Test Title"

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: regions
+#
+#  id   :integer          not null, primary key
+#  name :string
+#  slug :string
+#
+
 FactoryGirl.define do
   factory :region do
     name "DC Metro"

--- a/spec/factories/rsvps.rb
+++ b/spec/factories/rsvps.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: rsvps
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  event_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryGirl.define do
   factory :rsvp do
     user

--- a/spec/factories/subregions.rb
+++ b/spec/factories/subregions.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: subregions
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  region_id  :integer
+#
+
 FactoryGirl.define do
   factory :subregion do
     name "NoVA"

--- a/spec/factories/subscribers.rb
+++ b/spec/factories/subscribers.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: subscribers
+#
+#  id         :integer          not null, primary key
+#  email      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryGirl.define do
   factory :subscriber do
     sequence(:email) { |x| "test.user#{x}@gmail.com" }

--- a/spec/factories/user_city_relations.rb
+++ b/spec/factories/user_city_relations.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: user_city_relations
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  city_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryGirl.define do
   factory :user_city_relation do
     user

--- a/spec/factories/user_region_relations.rb
+++ b/spec/factories/user_region_relations.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: user_region_relations
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  region_id  :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 FactoryGirl.define do
   factory :user_region_relation do
     user 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,3 +1,11 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id   :integer          not null, primary key
+#  name :string
+#
+
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do

--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: cities
+#
+#  id           :integer          not null, primary key
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  subregion_id :integer
+#
+
 require 'rails_helper'
 
 RSpec.describe City, type: :model do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id       :integer          not null, primary key
+#  body     :string
+#  user_id  :integer
+#  event_id :integer
+#  post_id  :integer
+#
+
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do

--- a/spec/models/dislike_spec.rb
+++ b/spec/models/dislike_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: dislikes
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  item_type  :string
+#  item_id    :integer
+#
+
 require 'rails_helper'
 
 RSpec.describe Dislike, type: :model do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :integer          not null, primary key
+#  title       :string
+#  body        :text
+#  location    :string
+#  event_date  :datetime
+#  category_id :integer
+#  city_id     :integer
+#  user_id     :integer
+#  region_id   :integer
+#
+
 require 'rails_helper'
 
 RSpec.describe Event, type: :model do

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: likes
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  item_type  :string
+#  item_id    :integer
+#
+
 require 'rails_helper'
 
 RSpec.describe Like, type: :model do

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: posts
+#
+#  id          :integer          not null, primary key
+#  title       :string
+#  body        :text
+#  category_id :integer
+#  region_id   :integer
+#  user_id     :integer
+#
+
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: regions
+#
+#  id   :integer          not null, primary key
+#  name :string
+#  slug :string
+#
+
 require 'rails_helper'
 
 RSpec.describe Region, type: :model do

--- a/spec/models/rsvp_spec.rb
+++ b/spec/models/rsvp_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: rsvps
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  event_id   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe Rsvp, type: :model do

--- a/spec/models/subregion_spec.rb
+++ b/spec/models/subregion_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: subregions
+#
+#  id         :integer          not null, primary key
+#  name       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  region_id  :integer
+#
+
 require 'rails_helper'
 
 RSpec.describe Subregion, type: :model do

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: subscribers
+#
+#  id         :integer          not null, primary key
+#  email      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe Subscriber, type: :model do

--- a/spec/models/user_city_relation_spec.rb
+++ b/spec/models/user_city_relation_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: user_city_relations
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  city_id    :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe UserCityRelation, type: :model do

--- a/spec/models/user_region_relation_spec.rb
+++ b/spec/models/user_region_relation_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: user_region_relations
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  region_id  :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe UserRegionRelation, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0), not null
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :inet
+#  last_sign_in_ip        :inet
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  admin                  :boolean
+#  username               :string
+#  first_name             :string
+#  last_name              :string
+#  provider               :string
+#  uid                    :string
+#
+
 require 'rails_helper'
 
 RSpec.describe User, type: :model do


### PR DESCRIPTION
Here's what I did:

- added friendly_id slugs to the regions so now instead of id:1 it's slug: new-york-metro-area

- the region feed is now /new-york-metro-area/feed (:slug/feed)

- the individual event is now /new-york-metro-area/event/1 (:slug/event/:id)

- the individual post is now /new-york-metro-area/post/1 (:slug/post/:id)

- the region feed has posts and events and the titles link to the individual event/post

- the explore page has the list of all Regions

- to create a new region go to /region/new (works perfectly)

Also the navbar only shows the region name for when you are on the region feed, it still shows FEED but I'm going to change that to a logo or something

I think I'm going to also add slugs to the event id and post id
