### PR TITLE
adds css styling to region show/ posts & events

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -80,13 +80,12 @@ $grayLighter: #eeeeee;
   color: white;
 }
 
-.logo {
-  max-height: 100%;
-  max-width: 100%;
-}
-
-
 /* Navbar */
+
+.logo {
+  height: 67px;
+  width: 472px;
+}
 
 .navbar {
   height: 100%;
@@ -193,6 +192,22 @@ $grayLighter: #eeeeee;
 .authentication-container {
   margin-top:40px;
   width: 805px;
+}
+
+.settings-container {
+  margin-top: 40px;
+  width: 400px;
+}
+
+.settings-background {
+  padding-top: 25px;
+  padding-bottom: 25px;
+  padding-left: 30px;
+  padding-right: 30px;
+  background-color: white;
+  border-radius: 10px;
+  border-style: solid;
+  border-color: white;
 }
 
 .sign-up {
@@ -310,6 +325,105 @@ body {
     background-color: $yellow;
     border-color: $yellow;
   }
+}
+
+/* Region Posts & Events */
+
+.regions {
+  border-radius: 10px;
+  background-color: white;
+  padding-top: 15px;
+  padding-bottom: 15px;
+  margin-bottom: 10px;
+
+   .category-button {
+  font-size: 20px;
+  margin-bottom: 10px;
+  color: black;
+  background-color: white;
+  border-color: black;
+  padding-top: 1px;
+  padding-bottom: 1px;
+
+  &:hover {
+    color: white;
+    border-color: black;
+    background-color: black;
+  }
+ }
+
+ .subscribe-button {
+    font-size: 20px;
+    margin-bottom: 10px;
+    color: $pink;
+    background-color: white;
+    border-color: $pink;
+    padding-top: 1px;
+    padding-bottom: 1px;
+
+    &:hover {
+      color: white;
+      background-color: $pink;
+    }
+  }
+}
+
+.categories {
+  border-radius: 10px;
+  background-color: white;
+  padding-top: 20px;
+  padding-bottom: 15px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+
+  .category-button {
+  font-size: 20px;
+  margin-bottom: 10px;
+  color: black;
+  background-color: white;
+  border-color: black;
+  padding-top: 1px;
+  padding-bottom: 1px;
+
+  &:hover {
+    color: white;
+    border-color: black;
+    background-color: black;
+  }
+ }
+
+
+}
+
+.post {
+  background-color: white;
+  border-radius: 10px;
+  margin-bottom: 20px;
+}
+
+.event {
+  background-color: white;
+  border-radius: 10px;
+  margin-bottom: 20px;
+
+}
+
+.feed-margin {
+ margin-top: 20px;
+}
+
+.sidenav-margin {
+  margin-top: 20px;
+}
+
+.region {
+  border-bottom: 1px;
+  border-bottom-style: solid;
+  border-bottom-color: $pink;
+}
+
+.subregions {
+  margin-top: 10px;
 }
 
 /* footer */

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,25 +1,17 @@
-<div class="container login">
-  <div class="col-md-12 login-padding text-center">
-    <h3>Forgot your password?</h3>
-  </div>
-  <div class="col-md-12 login-padding login-margin-background">
+<div class="container settings-container">
+  <div class="col-md-12 settings-background">
+    <p class="text-left">RESET YOUR PASSWORD</p>
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-      <%= devise_error_messages! %>
 
-      <div class="field">
-        <%= f.label :email %><br />
-        <%= f.email_field :email, autofocus: true, class: "form-control" %>
-        <br>
+      <div class="field bottom-margin-form">
+        <%= f.email_field :email, placeholder: "email", autofocus: true, class: "form-control" %>
       </div>
 
-      <div class="actions">
+      <div class="actions bottom-margin-form">
         <%= f.submit "Send me reset password instructions", class: "btn btn-primary button-100" %>
       </div>
     <% end %>
-  </div>
-
-  <div class="col-lg-12 login-padding text-center login-margin-background">
-    <p class="no-margin"> Not what you're looking for? </p>
+    <p class="text-center">OR</p>
     <%= render "devise/shared/links" %>
   </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,65 +1,32 @@
-<div class="container login">
-  <div class="col-md-12 login-padding text-center">
-    <h3>Edit <%= resource_name.to_s.humanize %></h3>
-  </div>
-  <div class="col-md-12 login-padding login-margin-background login-background">
+<div class="container settings-container">
+  <div class="col-md-12 settings-background">
+    <p class="text-left">UPDATE YOUR INFORMATION</p>
     <%= form_for(resource, as: resource_name, url: "/users", html: { method: :put }) do |f| %>
-      <%= devise_error_messages! %>
-
       <div class="field">
-        <%= f.label :email %><br />
         <%= f.email_field :email, autofocus: true, class: "form-control" %>
-      </div>
-
-      <div class="field">
-        <%= f.label :username %><br />
-        <%= f.text_field :username, autofocus: true, class: "form-control" %>
-      </div>
-
-      <div class="row">
-        <div class="col-md-6">
-        <div class="field">
-          <%= f.label :first_name %><br />
-          <%= f.text_field :first_name, autofocus: true, class: "form-control" %>
-        </div>
-        </div>
-        <div class="col-md-6">
-        <div class="field">
-          <%= f.label :last_name %><br />
-          <%= f.text_field :last_name, autofocus: true, class: "form-control" %>
-        </div>
-        </div>
-      </div>
+      </div><br />
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
         <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
       <% end %>
 
       <div class="field">
-        <%= f.label "New Password" %> <i>(leave blank if you don't want to change it)</i><br />
-        <%= f.password_field :password, autocomplete: "off", class: "form-control" %>
-        <% if @minimum_password_length %>
-          <em><%= @minimum_password_length %> characters minimum</em>
-        <% end %>
-      </div>
+        <%= f.password_field :password, placeholder: "New password", autocomplete: "off", class: "form-control" %>
+      </div><br />
 
       <div class="field">
-        <%= f.label :password_confirmation %><br />
-        <%= f.password_field :password_confirmation, autocomplete: "off", class: "form-control" %>
-      </div>
+        <%= f.password_field :password_confirmation, placeholder: "Confirm new password", autocomplete: "on", class: "form-control" %>
+      </div><br />
 
       <div class="field">
-        <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-        <%= f.password_field :current_password, autocomplete: "off", class: "form-control" %>
-      </div>
+        <%= f.password_field :current_password, placeholder: "Current password (required)", class: "form-control" %>
+      </div><br />
 
-      <div class="actions">
-        <%= f.submit "Update", class: "btn btn-primary button-100" %>
+      <div class="actions bottom-margin-form">
+        <%= f.submit "Save your changes", class: "btn btn-primary button-100" %>
       </div>
     <% end %>
-    <br>
-    <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-primary button-100" %></p>
-
-    <%= link_to "Back", :back, class: "btn btn-sm button-100" %>
+    <p class="text-center bottom-margin-form">OR<p>
+    <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-primary button-100" %>
   </div>
 </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,9 +1,9 @@
 <%- if controller_name != 'sessions' %>
-  <p><%= link_to "Log in", new_session_path(resource_name), class: "btn btn-primary button-100" %></p>
+  <%= link_to "Log in", new_session_path(resource_name), class: "btn btn-primary button-100 bottom-margin-form" %>
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <p><%= link_to "Sign up", new_registration_path(resource_name), class: 'btn btn-primary button-100' %></p>
+  <%= link_to "Sign up", new_registration_path(resource_name), class: 'btn btn-primary button-100' %>
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -3,7 +3,7 @@
       <div class="col-xs-6">
         <div class="row">
           <div class="logo-margin">
-            <%= link_to image_tag('logo-pink.png', width: '60%', height: '60%'), root_path %>
+            <%= link_to image_tag('logo-pink.png', class: "logo"), root_path %>
           </div>
         </div>
       </div>
@@ -25,25 +25,6 @@
           <span><%= link_to 'FAQ', "#", class: "btn btn-primary nav-button" %></span>
         </div>
       </div>
-              <% if ['regions','posts','events'].include? params[:controller] %>
-                <% unless params[:action] == ('index' || 'new') %>
-                <div class="col-xs-12 category-nav">
-                  <div class="col-xs-6 text-left category-nav">
-                    <span><%= link_to @region.name, region_path(@region) , class: "btn btn-primary category-button" %></span>
-                    <% @subregions.each do |subregion| %>
-                      <span><%= link_to subregion.name, "#" , class: "btn btn-primary category-button" %></span>
-                    <% end %>
-                    <span><%= link_to 'Subscribe', '#' , class: "btn btn-primary subscribe-button" %>
-                    </span>
-                  </div>
-                  <div class="col-xs-6 text-right category-nav">
-                    <% @categories.each do |category| %>
-                      <span><%= link_to category.name, "#" , class: "btn btn-primary category-button" %></span>
-                    <% end %>
-                  </div>
-                </div>
-                <% end %>
-              <% end %>
     </div>
   </div>
 </nav>

--- a/app/views/regions/show.html.erb
+++ b/app/views/regions/show.html.erb
@@ -1,25 +1,40 @@
-<div class="container">
-  <h1> Events & Postings </h1>
-  <div class="container-fluid">
-    <div class="row">
-      <% @events.each do |event| %>
-      <div class="col-lg-12 text-left row alert event-row">
-        <h2><%= link_to event.title, region_event_path(@region.slug, event.slug) %></h2>
-        <h3><%= event.venue %></h3>
-        <h4><%= event.date %></h4>
-        <h4><%= event.time %></h4>
-        <p><%= event.body %></p>
-      </div>
-      <% end %>
+<div class="container-fluid col-lg-10 feed-margin">
+  <% @events.each do |event| %>
+    <div class="col-lg-12 text-left event">
+      <h3><%= link_to event.title, region_event_path(@region.slug, event.slug) %></h3>
+      <h4><%= event.venue %></h4>
+      <h4><%= event.date.strftime("%m.%d.%y")%> @ <%= event.time.strftime("%I:%M %p") %></h4>
     </div>
-    <div class="row">
-      <% @posts.each do |post| %>
-      <div class="col-lg-12 text-left row alert alert-info">
-      <h2><%= link_to post.title, region_post_path(@region.slug, post.slug) %></h2>
-      <p><%= post.body %></p>
-      <p>Posted on: <%= post.created_at.strftime("%D") %></p>
-      </div>
-      <% end %>
+  <% end %>
+  <% @posts.each do |post| %>
+    <div class="col-lg-12 text-left post">
+      <h3><%= link_to post.title, region_post_path(@region.slug, post.slug) %></h3>
+      <p>Posted <%= time_ago_in_words(post.created_at) %> ago by <%= link_to User.find(post.user_id).username, '#' %></p>
     </div>
+  <% end %>
+</div>
+
+<div class="container-fluid col-lg-2 sidenav-margin">
+    <div class="col-lg-12 regions">
+    <div class="region">
+      <%= link_to @region.name, region_path(@region) , class: "btn btn-primary category-button" %>
+          <%= link_to 'Subscribe', '#' , class: "btn btn-primary subscribe-button" %>
+
+    </div>
+    <div class="subregions">
+    <% @subregions.each do |subregion| %>
+      <div>
+        <%= link_to subregion.name, "#" , class: "btn btn-primary category-button" %>
+      </div>
+    <% end %>
+    </div>
+    </div>
+  <div class="col-lg-12 categories">
+  <% @categories.each do |category| %>
+                      <div>
+                        <%= link_to category.name, "#" , class: "btn btn-primary category-button" %>
+                      </div>
+                    <% end %>
   </div>
 </div>
+


### PR DESCRIPTION
So I did the styling for the posts & events, password reset, and settings for users. Here's a screenshot for the posts & events. The colors can be changed. I just wanted there to be proper columns, rows, etc.

This should close #48 

<img width="1636" alt="screen shot 2016-08-07 at 12 20 28 pm" src="https://cloud.githubusercontent.com/assets/15992549/17463700/b91187a2-5c99-11e6-8d51-42056fbf1150.png">
