### PR TITLE
Adding specs for creating event/posts. Updating associated views and …

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,7 @@
 class EventsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_region
+  before_action :set_city, only: [:create]
 
  def show
     @event = @region.events.friendly.find(params[:slug])
@@ -14,8 +16,8 @@ class EventsController < ApplicationController
   end
 
   def create
-    if @region.events.create!(event_params)
-      flash[:success] = "Thank you for creating a post"
+    if @city.events.create!(event_params)
+      flash[:success] = "Thank you for creating an Event"
       redirect_to region_path(@region)
     else
       flash[:danger] = "Sorry, something went wrong"
@@ -55,7 +57,11 @@ class EventsController < ApplicationController
     @region = Region.friendly.find(params[:region_slug])
   end
 
+  def set_city
+    @city = City.find(params[:event][:city_id])
+  end
+
   def event_params
-    params.require(:event).permit(:title, :body, :location, :event_date, :city_id, :category_id)
+    params.require(:event).permit(:title, :body, :venue, :date, :time, :city_id, :category_id).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,5 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_region
 
   def show
@@ -58,6 +59,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :body, :category_id)
+    params.require(:post).permit(:title, :body, :category_id).merge(user_id: current_user.id)
   end
 end

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -23,11 +23,11 @@
     </div>
     <div class="field">
       <%= f.label :category %>
-      <%= f.collection_select :category_id, Category.all, :id, :name, class: "form-control" %>
+      <%= f.collection_select :category_id, Category.all, :id, :name, {}, class: "form-control" %>
     </div>
     <div class="field">
       <%= f.label :city %>
-      <%= f.collection_select :city_id, City.all, :id, :name, class: "form-control" %>
+      <%= f.collection_select :city_id, City.all, :id, :name, {}, class: "form-control" %>
     </div>
     <%= f.submit "Create Event", class: "btn btn-primary" %>
   <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -11,7 +11,7 @@
     </div>
     <div class="field">
       <%= f.label :category %>
-      <%= f.collection_select :category_id, Category.all, :id, :name, class: "form-control" %>
+      <%= f.collection_select :category_id, Category.all, :id, :name, {}, class: "form-control" %>
     </div>
     <%= f.submit "Create Post", class: "btn btn-primary" %>
   <% end %>

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -1,0 +1,31 @@
+RSpec.feature "Event" do
+  let(:user) { FactoryGirl.create :user }
+  let(:region) { FactoryGirl.create :region }
+  let(:subregion) { FactoryGirl.create(:subregion, region: region) }
+  let(:city) { FactoryGirl.create(:city, subregion: subregion) }
+  let!(:event) { FactoryGirl.create(:event, city: city, title: "Test Event", body: "Test Event Body") }
+
+  scenario "Create Event" do
+    category = FactoryGirl.create(:category, name: "Comedy")
+    count = Event.count
+    sign_in user
+    visit new_region_event_path(region.slug)
+    fill_in "event[title]", with: "Kevin Hart: Laugh At My Pain"
+    fill_in "event[body]", with: "Kevin Hart takes the stage in Washington DC to put on his most anticipated stand up to date"
+    fill_in "event[venue]", with: "Verizon Center, Washington, D.C."
+    fill_in "event[date]", with: "01/01/2016"
+    fill_in "event[time]", with: "12:00 AM"
+    select "Comedy", from: "event[category_id]"
+    select city.name, from: "event[city_id]"
+    click_button "Create Event"
+    expect(page).to have_selector(".alert", text: "Thank you for creating an Event")
+    expect(Event.count).to be > count
+    expect(page).to have_selector(".event", text: "Kevin Hart: Laugh At My Pain")
+  end
+  scenario "View Event" do
+    sign_in user
+    visit region_event_path(region.slug, event.slug)
+    expect(page).to have_selector("h1", text: "Test Event")
+    expect(page).to have_selector("p", text: "Test Event Body")
+  end
+end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -1,0 +1,25 @@
+RSpec.feature "Post" do
+  let(:region) { FactoryGirl.create :region }
+  let(:post) { FactoryGirl.create(:post, region: region, title: "Test Post", body: "Test Post Body") }
+  let(:user) { FactoryGirl.create :user }
+
+  scenario "Create Post" do
+    category = FactoryGirl.create(:category, name: "Comedy")
+    count = Post.count
+    sign_in user
+    visit new_region_post_path(region.slug)
+    fill_in "post[title]", with: "Kevin Hart (Stand-up Profile)"
+    fill_in "post[body]", with: "Kevin Hart takes the stage in Washington DC to put on his most anticipated stand up to date"
+    select "Comedy", from: "post[category_id]"
+    click_button "Create Post"
+    expect(page).to have_selector(".alert", text: "Thank you for creating a post")
+    expect(Post.count).to be > count
+    expect(page).to have_selector(".post", text: "Kevin Hart (Stand-up Profile)")
+  end
+  scenario "View Post" do
+    sign_in user
+    visit region_post_path(region.slug, post.slug)
+    expect(page).to have_selector("h1", text: "Test Post")
+    expect(page).to have_selector("p", text: "Test Post Body")
+  end
+end


### PR DESCRIPTION
…controllers. References #28.

Does a ton of ish lol. This adds specs for creating events/posts and viewing them. It also updates the event/post controllers and views for new and create actions. It also enforces authentication for event/post creation which should start becoming required for most actions.

Feel free to take a look before merging. All specs are passing locally for me. 

![image](https://cloud.githubusercontent.com/assets/7366444/17468301/9c226034-5cf4-11e6-8d84-bf535dfed2df.png)
