### PR TITLE
Adding new notification interface

### DIFF
--- a/client/app/bundles/CommentBox/containers/CommentBox.jsx
+++ b/client/app/bundles/CommentBox/containers/CommentBox.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import CommentBoxWidget from '../components/CommentBoxWidget';
 import CommentList from '../components/CommentList';
 
+
 // Simple example of a React "smart" component
 export default class CommentBox extends React.Component {
   static propTypes = {

--- a/client/package.json
+++ b/client/package.json
@@ -10,25 +10,28 @@
     "build:production": "NODE_ENV=production webpack --config webpack.config.js",
     "build:development": "webpack -w --config webpack.config.js"
   },
-  "cacheDirectories": ["node_modules", "client/node_modules"],
+  "cacheDirectories": [
+    "node_modules",
+    "client/node_modules"
+  ],
   "dependencies": {
     "babel": "^6.5.2",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.4",
     "babel-loader": "^6.2.4",
-    "babel-runtime": "^6.6.1",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-runtime": "^6.6.1",
     "es5-shim": "^4.5.7",
     "expose-loader": "^0.7.1",
     "imports-loader": "^0.6.5",
     "react": "^0.14.8 || ^15.0.0",
     "react-dom": "^0.14.8 || ^15.0.0",
+    "react-notification-system": "^0.2.10",
     "react-on-rails": "6.0.5",
     "webpack": "^1.12.14"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "rspec"
   },
   "dependencies": {
-    "lodash": "^4.14.2"
+    "lodash": "^4.14.2",
+    "react-notification-system": "^0.2.10"
   }
 }

--- a/spec/features/comments/comment_on_event_spec.rb
+++ b/spec/features/comments/comment_on_event_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Commenting on Event", js: true do
         click_button "Add Comment"
         fill_in "comment-text", with: "This is a new test comment"
         click_button "Post"
-        expect(page).to have_selector(".alert-success", text: "Thanks!")
+        expect(page).to have_text("Your comment has been successfully posted. Thanks!")
       end
       it "adds comment to list" do
         click_button "Add Comment"
@@ -43,7 +43,7 @@ RSpec.feature "Commenting on Event", js: true do
         click_button "Add Comment"
         fill_in "comment-text", with: "This is a new test comment"
         click_button "Post"
-        expect(page).to have_selector(".alert-danger h4", text: "Oh snap! Something went wrong!")
+        expect(page).to have_text("Sorry for the inconvenience. Feel free to retry your action, or contact us at admin@wordsandmoves.com.")
       end
     end
     context "when user doesn't fill comment body" do

--- a/spec/features/comments/comment_on_post_spec.rb
+++ b/spec/features/comments/comment_on_post_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Commenting on post", js: true do
         click_button "Add Comment"
         fill_in "comment-text", with: "This is a new test comment"
         click_button "Post"
-        expect(page).to have_selector(".alert-success", text: "Thanks!")
+        expect(page).to have_text("Your comment has been successfully posted. Thanks!")
       end
       it "adds comment to list" do
         click_button "Add Comment"
@@ -42,7 +42,7 @@ RSpec.feature "Commenting on post", js: true do
         click_button "Add Comment"
         fill_in "comment-text", with: "This is a new test comment"
         click_button "Post"
-        expect(page).to have_selector(".alert-danger h4", text: "Oh snap! Something went wrong!")
+        expect(page).to have_text("Sorry for the inconvenience. Feel free to retry your action, or contact us at admin@wordsandmoves.com.")
       end
     end
     context "when user doesn't fill comment body" do


### PR DESCRIPTION
Ok so this updates the notification strategy to use the neat react notification plugin. Everything is working locally but the specs will most likely fail. I updated the specs so they should all be passing, but I am still seeing the PhantomJS error in regards to phantom crashing, not sure why 😕 Before local usage you will need to `npm install` in both the root and client directories I believe. This will effectively install the notification library to be used in react. Then you should be good to go. This is rebased on master as well.

Also I didn't push up my most recent webpack-bundle file considering it should not be stored here.

![ezgif com-video-to-gif 1](https://cloud.githubusercontent.com/assets/7366444/18331851/ea881d6a-752f-11e6-845e-67ce3c5f9d98.gif)
![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/7366444/18331852/ea8ab52a-752f-11e6-8326-f139c0f61fbc.gif)
